### PR TITLE
Update dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
 				"IsRegExp",
 				"RequireObjectCoercible",
 				"StringCharCodeAt",
-				"ToInteger",
+				"ToIntegerOrInfinity",
 				"ToString",
 			],
 		}],

--- a/implementation.js
+++ b/implementation.js
@@ -1,12 +1,11 @@
-/*! https://mths.be/endswith v1.0.0 by @mathias */
-
 'use strict';
 
-var callBound = require('es-abstract/helpers/callBound');
-var RequireObjectCoercible = require('es-abstract/2019/RequireObjectCoercible');
-var ToString = require('es-abstract/2019/ToString');
-var IsRegExp = require('es-abstract/2019/IsRegExp');
-var ToInteger = require('es-abstract/2019/ToInteger');
+var RequireObjectCoercible = require('es-abstract/2023/RequireObjectCoercible');
+var ToString = require('es-abstract/2023/ToString');
+var IsRegExp = require('es-abstract/2023/IsRegExp');
+var ToIntegerOrInfinity = require('es-abstract/2023/ToIntegerOrInfinity');
+
+var callBound = require('call-bind/callBound');
 
 var StringCharCodeAt = callBound('String.prototype.charCodeAt');
 var max = Math.max;
@@ -23,7 +22,7 @@ module.exports = function endsWith(searchString) {
 	var len = S.length;
 	var searchLength = searchStr.length;
 	var endPosition = arguments.length > 1 ? arguments[1] : undefined;
-	var pos = endPosition === undefined ? len : ToInteger(endPosition);
+	var pos = endPosition === undefined ? len : ToIntegerOrInfinity(endPosition);
 
 	var end = min(max(pos, 0), len);
 	var start = end - searchLength;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var callBind = require('es-abstract/helpers/callBind');
+var callBind = require('call-bind');
 var define = require('define-properties');
 
 var implementation = require('./implementation');

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
 		"cover": "istanbul cover --report html --verbose --dir coverage tape 'test/*.js'"
 	},
 	"dependencies": {
-		"define-properties": "^1.1.3",
-		"es-abstract": "^1.17.5"
+		"call-bind": "^1.0.2",
+		"define-properties": "^1.2.0",
+		"es-abstract": "^1.22.1"
 	},
 	"devDependencies": {
 		"@es-shims/api": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
 		"es-abstract": "^1.17.5"
 	},
 	"devDependencies": {
-		"@es-shims/api": "^2.1.2",
+		"@es-shims/api": "^2.4.2",
 		"@ljharb/eslint-config": "^21.1.0",
 		"aud": "^2.0.3",
 		"eslint": "=8.8.0",
 		"function-bind": "^1.1.1",
-		"functions-have-names": "^1.2.1",
+		"functions-have-names": "^1.2.3",
 		"istanbul": "^0.4.5",
-		"tape": "^5.0.0"
+		"tape": "^5.6.6"
 	}
 }


### PR DESCRIPTION
Make sure that dependencies are up to date, and use the 2020 version of `es-abstract` operations.